### PR TITLE
add stackscript to the linode namespace, keep it consistent

### DIFF
--- a/lib/linode.rb
+++ b/lib/linode.rb
@@ -27,7 +27,7 @@ class Linode
     end
   end
   
-  has_namespace :test, :avail, :user, :domain, :linode, :nodebalancer
+  has_namespace :test, :avail, :user, :domain, :linode, :nodebalancer, :stackscript
   
   @@documentation_category = {}
   

--- a/spec/linode_spec.rb
+++ b/spec/linode_spec.rb
@@ -449,5 +449,37 @@ describe 'Linode' do
       linode.nodebalancer.should == result
     end
   end
+
+  it 'should be able to provide access to the Linode Stackscript API' do
+    @linode.should respond_to(:stackscript)
+  end
+
+  describe 'when providing access to the Linode Stackscript API' do
+    it 'should allow no arguments' do
+      lambda { @linode.stackscript }.should_not raise_error(ArgumentError)
+    end
+
+    it 'should require no arguments' do
+      lambda { @linode.stackscript(:foo) }.should raise_error(ArgumentError)
+    end
+
+    it 'should return a Linode::Stackscript instance' do
+      @linode.stackscript.class.should == Linode::Stackscript
+    end
+
+    it 'should set the API key on the Linode::Stackscript instance to be our API key' do
+      @linode.stackscript.api_key.should == @api_key
+    end
+
+    it 'should set the API url on the Linode::Stackscript instance to be our API url' do
+      @linode.stackscript.api_url.should == @api_url
+    end
+
+    it 'should return the same Linode::Stackscript instance when called again' do
+      linode = Linode.new(:api_key => @api_key)
+      result = linode.stackscript
+      linode.stackscript.should == result
+    end
+  end
 end
 


### PR DESCRIPTION
Keeping it consistent by ensuring you can access the stackscript namespace thru the Linode class.
