### PR TITLE
use HTTParty built-in 'parsed_response' method instead of separate JSON.parse()

### DIFF
--- a/lib/linode.rb
+++ b/lib/linode.rb
@@ -90,7 +90,7 @@ class Linode
   end
 
   def post(data)
-    JSON.parse(HTTParty.post(api_url, :body => data))
+    HTTParty.post(api_url, :body => data).parsed_response
   end
 
   def error?(response)


### PR DESCRIPTION
Previously working 'cap deploy' no longer worked until I made this change.  Is likely a slight bit faster too...  ;-)
