### PR TITLE
Fix LoadError exception and deprecation warnings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,8 @@ source "http://rubygems.org"
 
 group :test do
   gem "rake","0.8.7"
-  gem "rspec","2.4.0"
-  gem "mocha"
+  gem "rspec", "~> 2.12.0"
+  gem "mocha", "~> 0.13.1"
 end
 
 gem "httparty"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,11 +8,11 @@ rescue LoadError
 end
 
 begin
-  require 'mocha'
+  require 'mocha/api'
 rescue LoadError
   require 'rubygems'
   gem 'mocha'
-  require 'mocha'
+  require 'mocha/api'
 end
 
 require 'httparty'


### PR DESCRIPTION
- RSpec 2.4.0 causes a LoadError with newer versions of Mocha
  (>= 0.13.0) when it tries to require a missing mocha/object.
- Set up-to-date version specifiers on the rspec and mocha gems.
- Fix deprecation warnings from Mocha saying that `require 'mocha/api'`
  should be used instead of `require 'mocha'`.
