### PR TITLE
Add linode.clone

### DIFF
--- a/lib/linode/linode.rb
+++ b/lib/linode/linode.rb
@@ -1,5 +1,5 @@
 class Linode::Linode < Linode
   documentation_category "linode"
   has_namespace :config, :disk, :ip, :job
-  has_method :update, :create, :list, :shutdown, :boot, :delete, :reboot
+  has_method :update, :create, :list, :shutdown, :boot, :delete, :reboot, :clone
 end

--- a/spec/linode/linode_spec.rb
+++ b/spec/linode/linode_spec.rb
@@ -11,7 +11,7 @@ describe Linode::Linode do
     @linode.class.should < Linode
   end
   
-  %w(update create list shutdown boot delete reboot).each do |action|
+  %w(update create list shutdown boot delete reboot clone).each do |action|
     it "should allow accessing the #{action} API" do
       @linode.should respond_to(action.to_sym)
     end


### PR DESCRIPTION
Just needed the 'linode.clone' method and found it was not there. This is what I did to add support for it.

BTW: I could not run the specs. Among many 'mocha' deprecation warnings I finnally got an error. Either in ruby1.9.3 or in ruby2.0.0:

```
*** Mocha deprecation warning: Change `require 'mocha'` to `require 'mocha/setup'`.


*** Mocha deprecation warning: Test::Unit or MiniTest must be loaded *before* Mocha.


*** Mocha deprecation warning: If you're integrating with a test library other than Test::Unit or MiniTest, you should use `require 'mocha/api'` instead of `require 'mocha'`.


*** Mocha deprecation warning: `require 'mocha/standalone'` has been deprecated. Please use `require 'mocha/api' instead.


/home/ruben/.rvm/gems/ruby-1.9.3-p429@linode/gems/rspec-core-2.4.0/lib/rspec/core/mocking/with_mocha.rb:2:in `require': cannot load such file -- mocha/object (LoadError)
    from /home/ruben/.rvm/gems/ruby-1.9.3-p429@linode/gems/rspec-core-2.4.0/lib/rspec/core/mocking/with_mocha.rb:2:in `<top (required)>'
    from /home/ruben/.rvm/gems/ruby-1.9.3-p429@linode/gems/rspec-core-2.4.0/lib/rspec/core/configuration.rb:164:in `require'
    from /home/ruben/.rvm/gems/ruby-1.9.3-p429@linode/gems/rspec-core-2.4.0/lib/rspec/core/configuration.rb:164:in `mock_framework='
    from /home/ruben/.rvm/gems/ruby-1.9.3-p429@linode/gems/rspec-core-2.4.0/lib/rspec/core/configuration.rb:123:in `mock_with'
    from /home/ruben/Documentos/codigo/linode/spec/spec_helper.rb:21:in `block in <top (required)>'
    from /home/ruben/.rvm/gems/ruby-1.9.3-p429@linode/gems/rspec-core-2.4.0/lib/rspec/core.rb:56:in `configure'
    from /home/ruben/Documentos/codigo/linode/spec/spec_helper.rb:20:in `<top (required)>'
    from /home/ruben/Documentos/codigo/linode/spec/linode_spec.rb:1:in `require'
    from /home/ruben/Documentos/codigo/linode/spec/linode_spec.rb:1:in `<top (required)>'
    from /home/ruben/.rvm/gems/ruby-1.9.3-p429@linode/gems/rspec-core-2.4.0/lib/rspec/core/configuration.rb:387:in `load'
    from /home/ruben/.rvm/gems/ruby-1.9.3-p429@linode/gems/rspec-core-2.4.0/lib/rspec/core/configuration.rb:387:in `block in load_spec_files'
    from /home/ruben/.rvm/gems/ruby-1.9.3-p429@linode/gems/rspec-core-2.4.0/lib/rspec/core/configuration.rb:387:in `map'
    from /home/ruben/.rvm/gems/ruby-1.9.3-p429@linode/gems/rspec-core-2.4.0/lib/rspec/core/configuration.rb:387:in `load_spec_files'
    from /home/ruben/.rvm/gems/ruby-1.9.3-p429@linode/gems/rspec-core-2.4.0/lib/rspec/core/command_line.rb:18:in `run'
    from /home/ruben/.rvm/gems/ruby-1.9.3-p429@linode/gems/rspec-core-2.4.0/lib/rspec/core/runner.rb:55:in `run_in_process'
    from /home/ruben/.rvm/gems/ruby-1.9.3-p429@linode/gems/rspec-core-2.4.0/lib/rspec/core/runner.rb:46:in `run'
    from /home/ruben/.rvm/gems/ruby-1.9.3-p429@linode/gems/rspec-core-2.4.0/lib/rspec/core/runner.rb:10:in `block in autorun'
rake aborted!


```
