### PR TITLE
Add optional logger to log every request

### DIFF
--- a/lib/linode.rb
+++ b/lib/linode.rb
@@ -5,6 +5,7 @@ require 'json'
 
 class Linode
   attr_reader :username, :password
+  attr_accessor :logger
 
   def self.has_method(*actions)
     actions.each do |action|
@@ -55,6 +56,7 @@ class Linode
 
   def initialize(args)
     @api_url = args[:api_url] if args[:api_url]
+    @logger = args[:logger]
 
     if args.include?(:api_key)
       @api_key = args[:api_key]
@@ -90,6 +92,7 @@ class Linode
   end
 
   def post(data)
+    @logger.info "POST #{api_url.to_s} body:#{data.inspect}" if @logger
     HTTParty.post(api_url, :body => data).parsed_response
   end
 


### PR DESCRIPTION
Just the possibility to set a logger for the Linode instance, either through initialize or the accessor. If it is given, then use it to log every single request. Nothing changes if it is not given.
