### PR TITLE
hook new Image endpoint into main Linode object

### DIFF
--- a/lib/linode.rb
+++ b/lib/linode.rb
@@ -29,7 +29,7 @@ class Linode
     end
   end
 
-  has_namespace :test, :avail, :user, :domain, :linode, :nodebalancer, :stackscript, :account
+  has_namespace :test, :avail, :user, :domain, :linode, :nodebalancer, :stackscript, :account, :image
 
   @@documentation_category = {}
 

--- a/spec/linode_spec.rb
+++ b/spec/linode_spec.rb
@@ -539,4 +539,32 @@ describe 'Linode' do
       linode.stackscript.should == result
     end
   end
+
+  describe 'when providing access to the Linode Image API' do
+    it 'should allow no arguments' do
+      lambda { @linode.image }.should_not raise_error
+    end
+
+    it 'should require no arguments' do
+      lambda { @linode.image(:foo) }.should raise_error(ArgumentError)
+    end
+
+    it 'should return a Linode::Image instance' do
+      @linode.image.class.should == Linode::Image
+    end
+
+    it 'should set the API key on the Linode::Image instance to be our API key' do
+      @linode.image.api_key.should == @api_key
+    end
+
+    it 'should set the API url on the Linode::Image instance to be our API url' do
+      @linode.image.api_url.should == @api_url
+    end
+
+    it 'should return the same Linode::Image instance when called again' do
+      linode = Linode.new(:api_key => @api_key)
+      result = linode.image
+      linode.image.should == result
+    end
+  end
 end


### PR DESCRIPTION
The `linode.image` namespace was missed in https://github.com/rick/linode/pull/23

```
displague@i:~/src/linode$ bundle exec irb -I lib
irb(main):001:0> require 'rubygems' ; require 'linode'; 
l = ::Linode.new :api_key=> 'abc123'
=> #<Linode:0x00000001e5ef60 @logger=nil, @api_key="abc123">
irb(main):002:0> l.image.list
NoMethodError: undefined method `image' for #<Linode:0x00000001e5ef60>
	from (irb):2
	from /usr/bin/irb:11:in `<main>'
```

The tests don't catch this because they jump right into the Linode::Image class, without using the Linode namespaces.

With this PR:
```
irb(main):005:0* l.image.list
=> [#<Linode::OpenStruct last_used_dt="", minsize=1, description="test description imageid1", label="test label imageid1", creator="displague", status="deleted", ispublic=0, create_dt="2014-09-03 00:53:21.0", type="manual", fs_type="ext3", imageid=9610>, ...]
irb(main):006:0> l.image.delete :imageid => 9610
=> [#<Linode::OpenStruct last_used_dt="", minsize=1, description="test description imageid1", label="test label imageid1", creator="displague", status="deleted", ispublic=0, create_dt="2014-09-03 01:17:27.0", type="manual", fs_type="ext3", imageid=9610>]
```

I see the need for testing that namespaces exist within Linode, but I'm not sure how you would approach this.  
Check for the existence of the tested item within `Linode` from each `spec/linode/*_spec` ?  Or would you have `linode_spec` check all known names (seems pointless) or derive the names from a directory listing?