### PR TITLE
Crack is not used anymore.

### DIFF
--- a/linode.gemspec
+++ b/linode.gemspec
@@ -27,6 +27,5 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency(%q<httparty>, ["~> 0.0"])
   s.add_runtime_dependency(%q<json>, ["~> 1.0"])
-  s.add_runtime_dependency(%q<crack>, ["~> 0.0"])
 end
 


### PR DESCRIPTION
It was removed already in a17fb935157b4b4d9b9351fe7 but then probably reappeared by mistake.