### PR TITLE
Add missing methods for linode.kvmify and linode.mutate

### DIFF
--- a/lib/linode/linode.rb
+++ b/lib/linode/linode.rb
@@ -1,5 +1,5 @@
 class Linode::Linode < Linode
   documentation_category "linode"
   has_namespace :config, :disk, :ip, :job
-  has_method :update, :create, :kvmify, :list, :shutdown, :boot, :delete, :reboot, :clone, :resize
+  has_method :update, :create, :kvmify, :list, :mutate, :shutdown, :boot, :delete, :reboot, :clone, :resize
 end

--- a/lib/linode/linode.rb
+++ b/lib/linode/linode.rb
@@ -1,5 +1,5 @@
 class Linode::Linode < Linode
   documentation_category "linode"
   has_namespace :config, :disk, :ip, :job
-  has_method :update, :create, :list, :shutdown, :boot, :delete, :reboot, :clone, :resize
+  has_method :update, :create, :kvmify, :list, :shutdown, :boot, :delete, :reboot, :clone, :resize
 end

--- a/spec/linode/linode_spec.rb
+++ b/spec/linode/linode_spec.rb
@@ -11,7 +11,7 @@ describe Linode::Linode do
     @linode.class.should < Linode
   end
 
-  %w(update create kvmify list shutdown boot delete reboot clone resize).each do |action|
+  %w(update create kvmify list mutate shutdown boot delete reboot clone resize).each do |action|
     it "should allow accessing the #{action} API" do
       @linode.should respond_to(action.to_sym)
     end

--- a/spec/linode/linode_spec.rb
+++ b/spec/linode/linode_spec.rb
@@ -11,7 +11,7 @@ describe Linode::Linode do
     @linode.class.should < Linode
   end
 
-  %w(update create list shutdown boot delete reboot clone resize).each do |action|
+  %w(update create kvmify list shutdown boot delete reboot clone resize).each do |action|
     it "should allow accessing the #{action} API" do
       @linode.should respond_to(action.to_sym)
     end


### PR DESCRIPTION
Both of these are missing in the current version of the gem and are necessary for anyone who needs to programmatically upgrade their Linodes from Xen to KVM and onto the new Linode plans.