### PR TITLE
Upgrade httparty

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+0.9.3 / 2019-12-28
+==================
+  * Upgrade httparty gem dependency
+
 0.9.2 / 2019-04-15
 ==================
   * Added custom HTTP User-Agent ("linode/%s ruby/%s")

--- a/linode.gemspec
+++ b/linode.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_runtime_dependency "httparty", "~> 0.0"
+  s.add_runtime_dependency "httparty", "~> 0.10"
 
   s.add_development_dependency "rake", "~> 10.0"
   s.add_development_dependency "rspec", "~> 2.0"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6259/71551432-077dfe00-29ad-11ea-96da-838cb0aca800.png)

This addresses a quite old security issue [CVE-2013-1801](https://github.com/advisories/GHSA-mgx3-27hr-mfgp).

It is not clear to me whether this library has a maintainer any longer (this was being maintained by the Linode team, but most of those people have moved on, and newer versions of the API are evidently obviating this). It's not clear if I can release a gem. I will at least offer up this change and will land it to master.